### PR TITLE
Move github workflows and update readme

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup
-      uses: densestvoid/workflows/actions/setup@main
+      uses: densestvoid/workflows/.github/actions/setup@main
       with:
         go-version: ${{ inputs.go-version }}
         
@@ -43,12 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup
-      uses: densestvoid/workflows/actions/setup@main
+      uses: densestvoid/workflows/.github/actions/setup@main
       with:
         go-version: ${{ inputs.go-version }}
 
     - name: Install staticcheck
-      uses: densestvoid/workflows/actions/install-tool@main
+      uses: densestvoid/workflows/.github/actions/install-tool@main
       with:
         tool-package: honnef.co/go/tools/cmd/staticcheck
 
@@ -61,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup
-      uses: densestvoid/workflows/actions/setup@main
+      uses: densestvoid/workflows/.github/actions/setup@main
       with:
         go-version: ${{ inputs.go-version }}
 
     - name: Install golangci-lint
-      uses: densestvoid/workflows/actions/install-tool@main
+      uses: densestvoid/workflows/.github/actions/install-tool@main
       with:
         tool-package: github.com/golangci/golangci-lint/cmd/golangci-lint
 
@@ -79,12 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup
-      uses: densestvoid/workflows/actions/setup@main
+      uses: densestvoid/workflows/.github/actions/setup@main
       with:
         go-version: ${{ inputs.go-version }}
 
     - name: Install govulncheck
-      uses: densestvoid/workflows/actions/install-tool@main
+      uses: densestvoid/workflows/.github/actions/install-tool@main
       with:
         tool-package: golang.org/x/vuln/cmd/govulncheck
 
@@ -97,12 +97,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup
-      uses: densestvoid/workflows/actions/setup@main
+      uses: densestvoid/workflows/.github/actions/setup@main
       with:
         go-version: ${{ inputs.go-version }}
 
     - name: Install gosec
-      uses: densestvoid/workflows/actions/install-tool@main
+      uses: densestvoid/workflows/.github/actions/install-tool@main
       with:
         tool-package: github.com/securego/gosec/v2/cmd/gosec
 


### PR DESCRIPTION
Update workflow action paths to correctly reference composite actions within the `.github` directory.

The workflow `go-checks.yml` was using incorrect paths (e.g., `densestvoid/workflows/actions/setup@main`) to reference composite actions. This PR corrects these references to `densestvoid/workflows/.github/actions/setup@main` to align with the standard GitHub repository structure and ensure proper action resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-ded4c233-7bcc-4922-842e-418d53fa4cd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ded4c233-7bcc-4922-842e-418d53fa4cd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

